### PR TITLE
Read test input as bytes instead of strings

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,18 +7,18 @@ mod tests{
     use std::io::prelude::*;
     use std::path::Path;
 
-    fn read_sample_file(sample_name: &str) -> String{
+    fn read_sample_file(sample_name: &str) -> Vec<u8> {
         let full_path = "sample/".to_string()+sample_name;
         let mut f = File::open(full_path).unwrap();
-        let mut s = String::new();
-        f.read_to_string(&mut s).unwrap();
+        let mut s = Vec::new();
+        f.read_to_end(&mut s).unwrap();
         s
     }
     use warc_parser;
     #[test]
     fn it_parses_a_plethora(){
         let examples = read_sample_file("picplz.warc");
-        let parsed = warc_parser::records(examples.as_bytes());
+        let parsed = warc_parser::records(&examples);
         println!("{:?}",parsed);
         assert!(parsed.is_done());
     }
@@ -26,7 +26,7 @@ mod tests{
     #[test]
     fn it_parses_single(){
         let bbc = read_sample_file("bbc.warc");
-        let parsed = warc_parser::record(bbc.as_bytes());
+        let parsed = warc_parser::record(&bbc);
         assert!(parsed.is_done());
     }
 }


### PR DESCRIPTION
Fixes a UTF-8 error when running tests on sample data.
