### PR TITLE
Update to build without warnings on Rust 1.8.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@
 //!Takes data and separates records in headers and content.
 #[macro_use]
 extern crate nom;
-use nom::{IResult, space, Needed, Err};
-use nom::IResult::*;
+use nom::{IResult, space, Needed};
 use std::str;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,19 +17,19 @@ pub struct Record{
 }
 impl<'a> Debug for Record {
     fn fmt(&self, form:&mut Formatter) -> Result {
-        write!(form, "\nHeaders:\n");
+        write!(form, "\nHeaders:\n").unwrap();
         for (name, value) in &self.headers {
-            write!(form, "{}", name);
-            write!(form, ": ");
-            write!(form, "{}", value);
-            write!(form, "\n");
+            write!(form, "{}", name).unwrap();
+            write!(form, ": ").unwrap();
+            write!(form, "{}", value).unwrap();
+            write!(form, "\n").unwrap();
         }
-        write!(form, "Content Length:{}\n", self.content.len());
+        write!(form, "Content Length:{}\n", self.content.len()).unwrap();
         let s = match String::from_utf8(self.content.clone()){
             Ok(s) => s,
             Err(_) => {"Could not convert".to_string()}
         };
-        write!(form, "Content :{:?}\n", s);
+        write!(form, "Content :{:?}\n", s).unwrap();
         write!(form, "\n")
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
-#![feature(test)]
-extern crate test;
 extern crate warc_parser;
 extern crate nom;
+
+#[cfg(tests)]
 mod tests{
     use std::fs::File;
     use std::io::prelude::*;


### PR DESCRIPTION
These are a few patches to fix compiler warnings on Rust 1.8.0 stable.  The change to the test is the only outright error, the rest are just warnings, but it seems cleaner to include them.  These follow accepted best practice to the best of my knowledge, but I'm still a Rust newbie, so if you know alternative solutions that are better, feel free to change.

Also, I noticed that the version of warc_parser up on crates.io has an API that doesn't match the GitHub repo (returns a HashMap<String, String> instead of a result struct).  Any chance you could re-upload?
