### PR TITLE
Return IResult::Incomplete if the input buffer doesn't include a full record.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 target
 Cargo.lock
+
+# Rustfmt backups
+*.rs.bk
+
+# Vim swap files
+*.sw?

--- a/sample/bbc.warc
+++ b/sample/bbc.warc
@@ -2,7 +2,7 @@ WARC/1.0
 WARC-Type: response
 WARC-Date: 2014-08-02T09:52:13Z
 WARC-Record-ID: <urn:uuid:ffbfb0c0-6456-42b0-af03-3867be6fc09f>
-Content-Length: 43428
+Content-Length: 26052
 Content-Type: application/http; msgtype=response
 WARC-Warcinfo-ID: <urn:uuid:3169ca8e-39a6-42e9-a4e3-9f001f067bdf>
 WARC-Concurrent-To: <urn:uuid:d99f2a24-158a-4c77-bb0a-3cccd40aad56>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,7 +4,7 @@ extern crate nom;
 mod tests {
     use std::fs::File;
     use std::io::prelude::*;
-    use nom::IResult;
+    use nom::{IResult, Needed};
 
     fn read_sample_file(sample_name: &str) -> Vec<u8> {
         let full_path = "sample/".to_string() + sample_name;
@@ -43,6 +43,18 @@ mod tests {
                 assert_eq!(empty, i);
                 assert_eq!(13, record.headers.len());
             }
+        }
+    }
+
+    #[test]
+    fn it_parses_incomplete() {
+        let bbc = read_sample_file("bbc.warc");
+        let parsed = warc_parser::record(&bbc[..bbc.len() - 10]);
+        assert!(!parsed.is_done());
+        match parsed {
+            IResult::Error(_) => assert!(false),
+            IResult::Incomplete(needed) => assert_eq!(Needed::Size(10), needed),
+            IResult::Done(_, _) => assert!(false),
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,13 @@
 extern crate warc_parser;
 extern crate nom;
 
-mod tests{
+mod tests {
     use std::fs::File;
     use std::io::prelude::*;
-    use nom::{IResult};
+    use nom::IResult;
 
     fn read_sample_file(sample_name: &str) -> Vec<u8> {
-        let full_path = "sample/".to_string()+sample_name;
+        let full_path = "sample/".to_string() + sample_name;
         let mut f = File::open(full_path).unwrap();
         let mut s = Vec::new();
         f.read_to_end(&mut s).unwrap();
@@ -15,15 +15,15 @@ mod tests{
     }
     use warc_parser;
     #[test]
-    fn it_parses_a_plethora(){
+    fn it_parses_a_plethora() {
         let examples = read_sample_file("plethora.warc");
         let parsed = warc_parser::records(&examples);
         assert!(parsed.is_done());
-        match parsed{
+        match parsed {
             IResult::Error(_) => assert!(false),
             IResult::Incomplete(_) => assert!(false),
             IResult::Done(i, records) => {
-                let empty: Vec<u8> =  Vec::new();
+                let empty: Vec<u8> = Vec::new();
                 assert_eq!(empty, i);
                 assert_eq!(8, records.len());
             }
@@ -31,15 +31,15 @@ mod tests{
     }
 
     #[test]
-    fn it_parses_single(){
+    fn it_parses_single() {
         let bbc = read_sample_file("bbc.warc");
         let parsed = warc_parser::record(&bbc);
         assert!(parsed.is_done());
-        match parsed{
+        match parsed {
             IResult::Error(_) => assert!(false),
             IResult::Incomplete(_) => assert!(false),
             IResult::Done(i, record) => {
-                let empty: Vec<u8> =  Vec::new();
+                let empty: Vec<u8> = Vec::new();
                 assert_eq!(empty, i);
                 assert_eq!(13, record.headers.len());
             }


### PR DESCRIPTION
nom supports streaming parsers via returning IResult::Incomplete and having the host code retry the parse after reading more into the buffer.  It'd be nice to access that; WARC files can easily be multi-gig, where loading everything into memory at once isn't reasonable.

I'm a bit unsure about the change to remove the WARC-Truncated logic.  [The spec](http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf) says that even when WARC-Truncated is set, Content-Length will be the actual, truncated length, and so it seems like the safest thing to do is to use that without modification so that multi-record parsers don't get confused and lose their place in the stream.  But it did require changing test data, so I wonder if you had an actual file with that Content-Length that was causing problems.

I may have other changes coming up in the near future; I'm trying to parse the Common Crawl, so there's pretty ample testdata.
