### PR TITLE
Nom upgrade 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["web", "archive", "parsing", "warc"]
 license = "MIT"
 
 [dependencies]
-nom = "4.0"
+nom = "4.2.3"
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["web", "archive", "parsing", "warc"]
 license = "MIT"
 
 [dependencies]
-nom = "2.0"
+nom = "4.0"
 
 [profile.bench]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ extern crate nom;
 use std::str;
 use std::collections::HashMap;
 use std::fmt;
-//use nom::{Offset, space, Needed, Consumer, ConsumerState, Input, Move, IResult, FileProducer, Producer};
 use nom::{Offset, space, Needed, IResult, Err};
 
 /// The WArc `Record` struct
@@ -18,120 +17,6 @@ pub struct Record {
     /// Content for call in a raw format
     pub content: Vec<u8>,
 }
-
-/*
-#[derive(PartialEq,Eq,Debug,Clone)]
-pub enum State {
-    Beginning,
-    End,
-    Done,
-    Error,
-}
-
-pub struct WarcConsumer {
-    pub c_state: ConsumerState<usize, (), Move>,
-    pub state: State,
-    // bad design should not be pub
-    pub counter: usize,
-    pub last_record: Option<Record>,
-}
-
-impl WarcConsumer {
-    pub fn new() -> Self {
-        WarcConsumer {
-            state: State::Beginning,
-            c_state: ConsumerState::Continue(Move::Consume(0)),
-            counter: 0,
-            last_record: None,
-        }
-    }
-}
-
-pub struct WarcStreamer {
-    file_producer: FileProducer,
-    consumer: WarcConsumer,
-}
-
-impl WarcStreamer {
-    pub fn new(file: &str) -> Result<Self, String> {
-        match FileProducer::new(file, 5000) {
-            Ok(producer) => {
-                Ok(WarcStreamer {
-                    file_producer: producer,
-                    consumer: WarcConsumer::new(),
-                })
-            }
-            Err(_) => Err(format!("Could not create FileProducer for {:?}", file)),
-        }
-    }
-}
-
-impl Iterator for WarcStreamer {
-    type Item = Record;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.file_producer.apply(&mut self.consumer);
-        match self.consumer.state {
-            State::Error => None,
-            _ => {
-                let result = self.consumer.last_record.clone();
-                result
-            }
-        }
-    }
-}
-
-impl<'a> Consumer<&'a [u8], usize, (), Move> for WarcConsumer {
-    fn state(&self) -> &ConsumerState<usize, (), Move> {
-        &self.c_state
-    }
-
-    fn handle(&mut self, input: Input<&'a [u8]>) -> &ConsumerState<usize, (), Move> {
-        match self.state {
-            State::Beginning => {
-                let end_of_file = match input {
-                    Input::Eof(_) => true,
-                    _ => false,
-                };
-                match input {
-                    Input::Empty | Input::Eof(None) => {
-                        self.state = State::Done;
-                        self.c_state = ConsumerState::Error(());
-                    }
-                    Input::Element(sl) | Input::Eof(Some(sl)) => {
-                        match record_complete(sl) {
-                            IResult::Error(_) => {
-                                self.state = State::End;
-                            }
-                            IResult::Incomplete(n) => {
-                                if !end_of_file {
-                                    self.c_state = ConsumerState::Continue(Move::Await(n));
-                                } else {
-                                    self.state = State::End;
-                                }
-                            }
-                            IResult::Done(i, entry) => {
-                                self.last_record = Some(entry);
-                                self.counter = self.counter + 1;
-                                self.state = State::Beginning;
-                                self.c_state = ConsumerState::Continue(Move::Consume(sl.offset(i)));
-                            }
-                        }
-                    }
-                }
-            }
-            State::End => {
-                self.state = State::Done;
-            }
-            State::Done | State::Error => {
-                self.state = State::Error;
-                self.c_state = ConsumerState::Error(())
-            }
-        };
-        &self.c_state
-    }
-}
-*/
 
 impl<'a> fmt::Debug for Record {
     fn fmt(&self, form: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ extern crate nom;
 use std::str;
 use std::collections::HashMap;
 use std::fmt;
-use nom::{Offset, space, Needed, Consumer, ConsumerState, Input, Move, IResult, FileProducer, Producer};
+//use nom::{Offset, space, Needed, Consumer, ConsumerState, Input, Move, IResult, FileProducer, Producer};
+use nom::{Offset, space, Needed, IResult, Err};
 
 /// The WArc `Record` struct
 #[derive(Clone)]
@@ -17,6 +18,8 @@ pub struct Record {
     /// Content for call in a raw format
     pub content: Vec<u8>,
 }
+
+/*
 
 #[derive(PartialEq,Eq,Debug,Clone)]
 pub enum State {
@@ -128,6 +131,7 @@ impl<'a> Consumer<&'a [u8], usize, (), Move> for WarcConsumer {
         &self.c_state
     }
 }
+*/
 
 impl<'a> fmt::Debug for Record {
     fn fmt(&self, form: &mut fmt::Formatter) -> fmt::Result {
@@ -152,68 +156,68 @@ fn version_number(input: &[u8]) -> IResult<&[u8], &[u8]> {
     for (idx, chr) in input.iter().enumerate() {
         match *chr {
             46 | 48...57 => continue,
-            _ => return IResult::Done(&input[idx..], &input[..idx]),
+            _ => return Ok((&input[idx..], &input[..idx])),
         }
     }
-    IResult::Incomplete(Needed::Size(1))
+    Err(Err::Incomplete(Needed::Size(1)))
 }
 
 fn utf8_allowed(input: &[u8]) -> IResult<&[u8], &[u8]> {
     for (idx, chr) in input.iter().enumerate() {
         match *chr {
-            0...31 => return IResult::Done(&input[idx..], &input[..idx]),
+            0...31 => return Ok((&input[idx..], &input[..idx])),
             _ => continue,
         }
     }
-    IResult::Incomplete(Needed::Size(1))
+    Err(Err::Incomplete(Needed::Size(1)))
 }
 
 fn token(input: &[u8]) -> IResult<&[u8], &[u8]> {
     for (idx, chr) in input.iter().enumerate() {
         match *chr {
             33 | 35...39 | 42 | 43 | 45 | 48...57 | 65...90 | 94...122 | 124 => continue,
-            _ => return IResult::Done(&input[idx..], &input[..idx]),
+            _ => return Ok((&input[idx..], &input[..idx])),
         }
     }
-    IResult::Incomplete(Needed::Size(1))
+    Err(Err::Incomplete(Needed::Size(1)))
 }
 
 named!(init_line <&[u8], (&str, &str)>,
-    chain!(
-        tag!("\r")?                 ~
-        tag!("\n")?                 ~
-        tag!("WARC")                ~
-        tag!("/")                   ~
-        space?                      ~
-        version: map_res!(version_number, str::from_utf8)~
-        tag!("\r")?                 ~
-        tag!("\n")                  ,
-        || {("WARCVERSION", version)}
+    do_parse!(
+        opt!(tag!("\r"))            >>
+        opt!(tag!("\n"))            >>
+        tag!("WARC")                >>
+        tag!("/")                   >>
+        opt!(space)                 >>
+        version: map_res!(version_number, str::from_utf8) >>
+        opt!(tag!("\r"))            >>
+        tag!("\n")                  >>
+        (("WARCVERSION", version))
     )
 );
 
 named!(header_match <&[u8], (&str, &str)>,
-    chain!(
-        name: map_res!(token, str::from_utf8)~
-        space?                      ~
-        tag!(":")                   ~
-        space?                      ~
-        value: map_res!(utf8_allowed, str::from_utf8)~
-        tag!("\r")?                 ~
-        tag!("\n")                  ,
-        || {(name, value)}
+    do_parse!(
+        name: map_res!(token, str::from_utf8) >>
+        opt!(space)                 >>
+        tag!(":")                   >>
+        opt!(space)                 >>
+        value: map_res!(utf8_allowed, str::from_utf8) >>
+        opt!(tag!("\r"))            >>
+        tag!("\n")                  >>
+        ((name, value))
     )
 );
 
 named!(header_aggregator<&[u8], Vec<(&str,&str)> >, many1!(header_match));
 
 named!(warc_header<&[u8], ((&str, &str), Vec<(&str,&str)>) >,
-    chain!(
-        version: init_line          ~
-        headers: header_aggregator  ~
-        tag!("\r")?                 ~
-        tag!("\n")                  ,
-        move ||{(version, headers)}
+    do_parse!(
+        version: init_line          >>
+        headers: header_aggregator  >>
+        opt!(tag!("\r"))            >>
+        tag!("\n")                  >>
+        ((version, headers))
     )
 );
 
@@ -231,8 +235,8 @@ named!(warc_header<&[u8], ((&str, &str), Vec<(&str,&str)>) >,
 ///  let parsed = warc_parser::record(&bbc);
 ///  match parsed{
 ///      IResult::Error(_) => assert!(false),
-///      IResult::Incomplete(_) => assert!(false),
-///      IResult::Done(i, entry) => {
+///      Err::Incomplete(_) => assert!(false),
+///      Ok((i, entry)) => {
 ///          let empty: Vec<u8> =  Vec::new();
 ///          assert_eq!(empty, i);
 ///          assert_eq!(13, entry.headers.len());
@@ -243,8 +247,7 @@ pub fn record(input: &[u8]) -> IResult<&[u8], Record> {
     let mut h: HashMap<String, String> = HashMap::new();
     // TODO if the stream parser does not get all the header it fails .
     // like a default size of 10 doesnt for for a producer
-    match warc_header(input) {
-        IResult::Done(mut i, tuple_vec) => {
+    warc_header(input).and_then(|(mut i, tuple_vec)| {
             let (name, version) = tuple_vec.0;
             h.insert(name.to_string(), version.to_string());
             let headers = tuple_vec.1; // not need figure it out
@@ -274,24 +277,21 @@ pub fn record(input: &[u8]) -> IResult<&[u8], Record> {
                         headers: h,
                         content: content.to_vec(),
                     };
-                    IResult::Done(i, entry)
+                    Ok((i, entry))
                 }
-                None => IResult::Incomplete(Needed::Size(bytes_needed)),
+                None => Err(Err::Incomplete(Needed::Size(bytes_needed))),
             }
-        }
-        IResult::Incomplete(a) => IResult::Incomplete(a),
-        IResult::Error(a) => IResult::Error(a),
-    }
+    })
 }
 
 named!(record_complete <&[u8], Record >,
-    chain!(
-        entry: record              ~
-        tag!("\r")?                 ~
-        tag!("\n")                  ~
-        tag!("\r")?                 ~
-        tag!("\n")                  ,
-        move ||{entry}
+    do_parse!(
+        entry: record              >>
+        opt!(tag!("\r"))           >>
+        tag!("\n")                 >>
+        opt!(tag!("\r"))           >>
+        tag!("\n")                 >>
+        (entry)
     )
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,13 +285,15 @@ pub fn record(input: &[u8]) -> IResult<&[u8], Record> {
 }
 
 named!(record_complete <&[u8], Record >,
-    do_parse!(
-        entry: record              >>
-        opt!(tag!("\r"))           >>
-        tag!("\n")                 >>
-        opt!(tag!("\r"))           >>
-        tag!("\n")                 >>
-        (entry)
+    complete!(
+        do_parse!(
+            entry: record              >>
+            opt!(tag!("\r"))           >>
+            tag!("\n")                 >>
+            opt!(tag!("\r"))           >>
+            tag!("\n")                 >>
+            (entry)
+        )
     )
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ pub struct Record {
 }
 
 /*
-
 #[derive(PartialEq,Eq,Debug,Clone)]
 pub enum State {
     Beginning,
@@ -66,6 +65,7 @@ impl WarcStreamer {
         }
     }
 }
+
 impl Iterator for WarcStreamer {
     type Item = Record;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,9 +4,8 @@ extern crate nom;
 mod tests {
     use std::fs::File;
     use std::io::prelude::*;
-    //use nom::{IResult, Needed, FileProducer};
     use nom::{Err, IResult, Needed};
-    //use nom::{Producer, ConsumerState, Move};
+
     fn read_sample_file(sample_name: &str) -> Vec<u8> {
         let full_path = "sample/".to_string() + sample_name;
         let mut f = File::open(full_path).unwrap();
@@ -14,52 +13,8 @@ mod tests {
         f.read_to_end(&mut s).unwrap();
         s
     }
-    use warc_parser;
-    // TODO organize this mess
-    /*
-    #[test]
-    fn it_iterators() {
-        unimplemented!("not here yet");
-        let warc_streamer = warc_parser::WarcStreamer::new("sample/plethora.warc").unwrap();
-        let mut count = 0;
-        for record in warc_streamer {
-            println!("record::{:?}", record);
-            count += 1;
-        }
-        assert_eq!(count, 8);
-    }
-    #[test]
-    fn it_stream_parses_incomplete_file() {
-        unimplemented!("not here yet");
-        let mut producer = FileProducer::new("sample/bbc.warc", 5000).unwrap();
-        let mut consumer = warc_parser::WarcConsumer {
-            state: warc_parser::State::Beginning,
-            c_state: ConsumerState::Continue(Move::Consume(0)),
-            counter: 0,
-            last_record: None,
-        };
-        while let &ConsumerState::Continue(_) = producer.apply(&mut consumer) {
-        }
-        assert_eq!(consumer.counter, 0);
-        assert_eq!(consumer.state, warc_parser::State::Error);
-    }
 
-    #[test]
-    fn it_stream_parses_file() {
-        unimplemented!("not here yet");
-        let mut producer = FileProducer::new("sample/plethora.warc", 50000).unwrap();
-        let mut consumer = warc_parser::WarcConsumer {
-            state: warc_parser::State::Beginning,
-            c_state: ConsumerState::Continue(Move::Consume(0)),
-            counter: 0,
-            last_record: None,
-        };
-        while let &ConsumerState::Continue(_) = producer.apply(&mut consumer) {
-        }
-        assert_eq!(consumer.counter, 8);
-        assert_eq!(consumer.state, warc_parser::State::Done);
-    }
-*/
+    use warc_parser;
 
     #[test]
     fn it_parses_a_plethora() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -59,6 +59,7 @@ mod tests {
         assert_eq!(consumer.counter, 8);
         assert_eq!(consumer.state, warc_parser::State::Done);
     }
+*/
 
     #[test]
     fn it_parses_a_plethora() {
@@ -67,14 +68,14 @@ mod tests {
         assert!(parsed.is_ok());
         match parsed {
             Err(_) => assert!(false),
-            Ok(((i, records)) => {
+            Ok((i, records)) => {
                 let empty: Vec<u8> = Vec::new();
                 assert_eq!(empty, i);
                 assert_eq!(8, records.len());
             }
         }
     }
-*/
+
     #[test]
     fn it_parses_single() {
         let bbc = read_sample_file("bbc.warc");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,8 +4,9 @@ extern crate nom;
 mod tests {
     use std::fs::File;
     use std::io::prelude::*;
-    use nom::{IResult, Needed, FileProducer};
-    use nom::{Producer, ConsumerState, Move};
+    //use nom::{IResult, Needed, FileProducer};
+    use nom::{Err, IResult, Needed};
+    //use nom::{Producer, ConsumerState, Move};
     fn read_sample_file(sample_name: &str) -> Vec<u8> {
         let full_path = "sample/".to_string() + sample_name;
         let mut f = File::open(full_path).unwrap();
@@ -15,8 +16,10 @@ mod tests {
     }
     use warc_parser;
     // TODO organize this mess
+    /*
     #[test]
     fn it_iterators() {
+        unimplemented!("not here yet");
         let warc_streamer = warc_parser::WarcStreamer::new("sample/plethora.warc").unwrap();
         let mut count = 0;
         for record in warc_streamer {
@@ -27,6 +30,7 @@ mod tests {
     }
     #[test]
     fn it_stream_parses_incomplete_file() {
+        unimplemented!("not here yet");
         let mut producer = FileProducer::new("sample/bbc.warc", 5000).unwrap();
         let mut consumer = warc_parser::WarcConsumer {
             state: warc_parser::State::Beginning,
@@ -42,6 +46,7 @@ mod tests {
 
     #[test]
     fn it_stream_parses_file() {
+        unimplemented!("not here yet");
         let mut producer = FileProducer::new("sample/plethora.warc", 50000).unwrap();
         let mut consumer = warc_parser::WarcConsumer {
             state: warc_parser::State::Beginning,
@@ -59,27 +64,25 @@ mod tests {
     fn it_parses_a_plethora() {
         let examples = read_sample_file("plethora.warc");
         let parsed = warc_parser::records(&examples);
-        assert!(parsed.is_done());
+        assert!(parsed.is_ok());
         match parsed {
-            IResult::Error(_) => assert!(false),
-            IResult::Incomplete(_) => assert!(false),
-            IResult::Done(i, records) => {
+            Err(_) => assert!(false),
+            Ok(((i, records)) => {
                 let empty: Vec<u8> = Vec::new();
                 assert_eq!(empty, i);
                 assert_eq!(8, records.len());
             }
         }
     }
-
+*/
     #[test]
     fn it_parses_single() {
         let bbc = read_sample_file("bbc.warc");
         let parsed = warc_parser::record(&bbc);
-        assert!(parsed.is_done());
+        assert!(parsed.is_ok());
         match parsed {
-            IResult::Error(_) => assert!(false),
-            IResult::Incomplete(_) => assert!(false),
-            IResult::Done(i, record) => {
+            Err(_) => assert!(false),
+            Ok((i, record)) => {
                 let empty: Vec<u8> = Vec::new();
                 assert_eq!(empty, i);
                 assert_eq!(13, record.headers.len());
@@ -91,11 +94,11 @@ mod tests {
     fn it_parses_incomplete() {
         let bbc = read_sample_file("bbc.warc");
         let parsed = warc_parser::record(&bbc[..bbc.len() - 10]);
-        assert!(!parsed.is_done());
+        assert!(!parsed.is_ok());
         match parsed {
-            IResult::Error(_) => assert!(false),
-            IResult::Incomplete(needed) => assert_eq!(Needed::Size(10), needed),
-            IResult::Done(_, _) => assert!(false),
+            Err(Err::Incomplete(needed)) => assert_eq!(Needed::Size(10), needed),
+            Err(_) => assert!(false),
+            Ok((_, _)) => assert!(false),
         }
     }
 }


### PR DESCRIPTION
I have tried to tread lightly on this crate with these changes, but the jump from nom 2.0 to 4.0 is pretty substantial. I followed through the changes in https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md on the first 3 commits. 

The last commit is where my changes may be too much. Since nom dropped Producers and Consumers ("Producers and consumers were removed in nom 4. That feature was too hard to integrate in code that deals with IO.") I felt that with that being removed from nom it pushed this functionality outside of the scope of this crate. 

If you feel that ce8930c was a misstep, please let me know a good way to get this working and I can try to get it going as well. 